### PR TITLE
Update dependencies and change API end-points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ etc/packages/wallet.yaml
 /vendor/
 /web/bundles/
 ###< symfony/framework-bundle ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php_cs
+/.php_cs.cache
+###< friendsofphp/php-cs-fixer ###
+
+###> phpunit/phpunit ###
+/phpunit.xml
+.phpunit.result.cache
+###< phpunit/phpunit ###

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ![Console Dashboard](/resources/console.png?raw=true)
 ![Web Dashboard](/resources/web.png?raw=true)
 
-
 ## Install
 
 To start using the dashboard you need to clone the project and setup your wallet
@@ -20,6 +19,27 @@ $ git clone https://github.com/MarijnKoesen/cryptocoin-wallet-dashboard.git
 $ cd cryptocoin-wallet-dashboard.git
 $ cp .env.dist .env
 $ cp etc/packages/wallet.yaml.dist etc/packages/wallet.yaml
+```
+
+## Configure API keys
+
+**CoinMarketCap API**: Sign up at https://pro.coinmarketcap.com/signup/ and get the free developer API key.
+Then edit `etc/container.yaml` and set `coinmarketcap`'s `key` value.
+
+```
+parameters:
+    api:
+        coinmarketcap:
+            key: '<< HERE >>'
+```
+
+**Fixer API**: Sign up at https://fixer.io/product/ and get the free API key.
+Then edit `etc/container.yaml` and set `fixer`'s `key` value.
+```
+parameters:
+    api:
+        fixer:
+            key: '<< HERE >>'
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
         "symfony/twig-bundle": "^3.3",
-        "symfony/yaml": "^3.3"
+        "symfony/yaml": "^3.3",
+        "ext-json": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3",
@@ -42,7 +43,7 @@
     "scripts": {
         "auto-scripts": {
             "make cache-warmup": "script",
-            "assets:install --symlink --relative %WEB_DIR%": "symfony-cmd"
+            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
             "@auto-scripts"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "963467110e7ee991f4b9d60791c8a11c",
+    "content-hash": "e61acffd1dafce84f1129d01cf1cb6d0",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -132,16 +132,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
@@ -151,13 +151,16 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
@@ -190,7 +193,11 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28T22:50:30+00:00"
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/master"
+            },
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1113,16 +1120,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.2.1",
+            "version": "6.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374"
+                "reference": "ff3a76a58ac293657808aefd58c8aaf05945f4d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
-                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ff3a76a58ac293657808aefd58c8aaf05945f4d9",
+                "reference": "ff3a76a58ac293657808aefd58c8aaf05945f4d9",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1149,7 @@
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^4.0",
                 "sebastian/comparator": "^2.0",
-                "sebastian/diff": "^1.4.3 || ^2.0",
+                "sebastian/diff": "^1.4.3",
                 "sebastian/environment": "^3.0.2",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^1.1 || ^2.0",
@@ -1193,7 +1200,11 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-02T12:24:37+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/6.2"
+            },
+            "time": "2017-08-03T13:59:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2711,30 +2722,33 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.0.2",
+            "version": "v1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "bc51ab9c42ec2eb065643e5a26883e9e7ec05149"
+                "reference": "e472606b4b3173564f0edbca8f5d32b52fc4f2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/bc51ab9c42ec2eb065643e5a26883e9e7ec05149",
-                "reference": "bc51ab9c42ec2eb065643e5a26883e9e7ec05149",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/e472606b4b3173564f0edbca8f5d32b52fc4f2c9",
+                "reference": "e472606b4b3173564f0edbca8f5d32b52fc4f2c9",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
-                "php": "^7.1"
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=7.1"
             },
             "require-dev": {
-                "composer/composer": "^1.4",
-                "symfony/phpunit-bridge": "^3.2.8"
+                "composer/composer": "^1.0.2|^2.0",
+                "symfony/dotenv": "^4.4|^5.0",
+                "symfony/filesystem": "^4.4|^5.0",
+                "symfony/phpunit-bridge": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.4|^5.0"
             },
             "type": "composer-plugin",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "1.12-dev"
                 },
                 "class": "Symfony\\Flex\\Flex"
             },
@@ -2753,7 +2767,26 @@
                     "email": "fabien.potencier@gmail.com"
                 }
             ],
-            "time": "2017-05-27T15:33:17+00:00"
+            "description": "Composer plugin for Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/flex/issues",
+                "source": "https://github.com/symfony/flex/tree/v1.12.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-16T14:05:05+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -3346,6 +3379,9 @@
             ],
             "description": "Symfony TwigBundle",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bundle/tree/master"
+            },
             "time": "2017-05-12T17:24:04+00:00"
         },
         {
@@ -4130,10 +4166,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.3"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }

--- a/etc/container.yaml
+++ b/etc/container.yaml
@@ -1,46 +1,49 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
+    api:
+        coinmarketcap:
+            key: '< HERE >'
+            url: 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=5000'
+            # With the free version it's the above URL for all coins at once.
+            # The Paid API gives access to the following endpoint that allows filtering per coin:
+            # https://pro-api.coinmarketcap.com/v1/cryptocurrency/market-pairs/latest
+        fixer:
+            key: '< HERE >'
+            url: 'http://data.fixer.io/latest?access_key={api_key}&symbols={from},{to}'
+            # Paid version has the following endpoint available (and also the one that allows "base")
+            # http://api.fixer.io/latest?access_key={api_key}&from={from}&to={to}
+
     coins:
         BCN:
             name: Bytecoin
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/bytecoin-bcn/'
 
         DASH:
             name: Dash
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/dash/'
 
         ETH:
             name: Ethereum
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/ethereum/'
 
         LTC:
             name: Litecoin
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/litecoin/'
 
         STRAT:
             name: Stratis
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/stratis/'
 
         WAVES:
             name: Waves
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/waves/'
 
         XBT:
             name: Bitcoin
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/bitcoin/'
 
         XEM:
             name: NEM
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/nem/'
 
         XMR:
             name: Monero
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/monero/'
 
         XRP:
             name: Ripple
-            tickerApi: 'https://api.coinmarketcap.com/v1/ticker/ripple/'
 
 imports:
     - { resource: 'container/guzzle.yaml' }
@@ -53,10 +56,12 @@ services:
 
      MarijnKoesen\CryptocoinWalletDashboard\Rates\MoneyRateProvider\Fixer:
          arguments:
+            - '%api%'
             - '@guzzle'
 
      MarijnKoesen\CryptocoinWalletDashboard\Rates\CoinRateProvider\MarketCap:
          arguments:
+            - '%api%'
             - '%coins%'
             - '@MarijnKoesen\CryptocoinWalletDashboard\Rates\MoneyRateProvider\Fixer'
             - '@guzzle'
@@ -71,7 +76,7 @@ services:
         class: NumberFormatter
         arguments:
             - 'en_US'
-            - !php/const:NumberFormatter::CURRENCY
+            - !php/const:\NumberFormatter::CURRENCY
 
      currencies:
         class: Money\Currencies\ISOCurrencies

--- a/src/Rates/MoneyRateProvider/Fixer.php
+++ b/src/Rates/MoneyRateProvider/Fixer.php
@@ -10,12 +10,18 @@ use RuntimeException;
 final class Fixer implements MoneyRateProvider
 {
     /**
+     * @var array
+     */
+    private $apiConfig;
+
+    /**
      * @var ClientInterface
      */
     private $guzzle;
 
-    public function __construct(ClientInterface $guzzle)
+    public function __construct(array $apiConfig, ClientInterface $guzzle)
     {
+        $this->apiConfig = $apiConfig;
         $this->guzzle = $guzzle;
     }
 
@@ -24,7 +30,10 @@ final class Fixer implements MoneyRateProvider
         $fromString = strtoupper($from->getCode());
         $toString = strtoupper($to->getCode());
 
-        $apiEndPoint = 'http://api.fixer.io/latest?base=' . $fromString . '&symbols=' . $toString;
+        $apiEndPoint = $this->apiConfig['fixer']['url'];
+        $apiEndPoint = str_replace('{api_key}', $this->apiConfig['fixer']['key'], $apiEndPoint);
+        $apiEndPoint = str_replace('{from}', $fromString, $apiEndPoint);
+        $apiEndPoint = str_replace('{to}', $toString, $apiEndPoint);
 
         $apiResponse = $this->guzzle->request('GET', $apiEndPoint)->getBody();
         $data = json_decode($apiResponse, true);

--- a/tests/Rates/CoinRateProvider/MarketCapTest.php
+++ b/tests/Rates/CoinRateProvider/MarketCapTest.php
@@ -46,9 +46,9 @@ final class MarketCapTest extends TestCase
     /**
      * @test
      */
-    public function anExceptionIsThrownForAnUnkonwnCoin()
+    public function anExceptionIsThrownForAnUnknownCoin()
     {
-        $provider = new MarketCap([], $this->getMoneyRateProviderThatIsNotCalled(), new Client());
+        $provider = new MarketCap([], [], $this->getMoneyRateProviderThatIsNotCalled(), new Client());
 
         $this->expectException(RuntimeException::class);
         $provider->getRate(Coin::BITCOIN(), new Currency('CAD'));
@@ -107,6 +107,7 @@ final class MarketCapTest extends TestCase
         $client = $this->getGuzzleMock($apiResult);
 
         $provider = new MarketCap(
+            [],
             [
                 $coin->getValue() => [
                     'tickerApi' => 'http://the.api'

--- a/tests/Rates/MoneyRateProvider/FixerTest.php
+++ b/tests/Rates/MoneyRateProvider/FixerTest.php
@@ -21,9 +21,10 @@ final class FixerTest extends TestCase
      */
     public function fetchingRate()
     {
-        $apiResult = '{"base":"EUR","date":"2017-05-31","rates":{"GBP":0.87365,"USD":1.1221}}';
+        $apiResult = '{"success":true,"timestamp":1615828626,"base":"EUR","date":"2021-03-15","rates":{"GBP":0.87365,"USD":1.1221}}';
         $client = $this->getGuzzleMock($apiResult);
-        $provider = new Fixer($client);
+        $mockConfig = ['fixer' => ['key' => '', 'url' => 'mock_url']];
+        $provider = new Fixer($mockConfig, $client);
 
         $rate = $provider->getRate(new Currency('EUR'), new Currency('USD'));
         self::assertEquals(1.1221, $rate, '', 0.0000001);
@@ -34,9 +35,10 @@ final class FixerTest extends TestCase
      */
     public function anExceptionIsThrownForNotFoundCurrency()
     {
-        $apiResult = '{"base":"EUR","date":"2017-05-31","rates":{"GBP":0.87365,"USD":1.1221}}';
+        $apiResult = '{"success":true,"timestamp":1615828626,"base":"EUR","date":"2021-03-15","rates":{"GBP":0.87365,"USD":1.1221}}';
         $client = $this->getGuzzleMock($apiResult);
-        $provider = new Fixer($client);
+        $mockConfig = ['fixer' => ['key' => '', 'url' => 'mock_url']];
+        $provider = new Fixer($mockConfig, $client);
 
         self::expectException(RuntimeException::class);
         $provider->getRate(new Currency('EUR'), new Currency('CAD'));


### PR DESCRIPTION
- Minimally updated dependencies with composer until the code worked again on my Ubuntu 20.04 box.

php composer.phar update symfony/flex
php composer.phar update guzzlehttp/guzzle

I experimented with updating more stuff with php composer.phar update --prefer-lowest
However, there are quite a few conflicts that need to be resolved in that case.

- Change endpoints for CoinMarketCap and Fixer APIs.

The original end-points unfortunately ones are no longer existent :(
The remaining end-points require a developer Key, and they don't offer the same functionality (for free)
However, the scripts should at least work again.

- Updated a few phpunit tests, however, most tests are still failing due to an old phpunit.

-----
I'm not super familiar with guzzle, but I suspect we can cache the big new API call ( https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=5000 )
So that it won't have to be done for each coin, which is pretty slow.

Now that I added API key placeholders in `etc/container.yaml`, I think it would be better to move those to a `etc/secrets.yaml{.dist}`.